### PR TITLE
Add target_url and description fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ jobs:
           # Defaults to `default`
           context: default
 
+          # The target URL to associate with the Status (Optional)
+          # This URL will be linked from the Github UI to allow users to easily see the source of the status.
+          target_utl: https://example.target_url.com
+
+          # A short description of the status (Optional)
+          description: "dober dan"
+
         env:
           # Default Github Token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/action.yml
+++ b/action.yml
@@ -25,3 +25,9 @@ inputs:
     description: Name to identify the Status.
     required: false
     default: default
+  target_url:
+    description: The target URL to associate with this status.
+    required: false
+  description:
+    description: A short description of the status.
+    required: false


### PR DESCRIPTION
Target URL can be used to link the Heroku app. This can useful in switching between Github and Heroku.